### PR TITLE
Fixing indent level when it undergoes non-incrementing changes.

### DIFF
--- a/toc.js
+++ b/toc.js
@@ -37,10 +37,18 @@
       }
       if (this_level === level) // same level as before; same indenting
         html += "<li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
-      else if (this_level < level) // higher level than before; end parent ol
-        html += "</li></"+settings.listType+"></li><li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
-      else if (this_level > level) // lower level than before; expand the previous to contain a ol
-        html += "<"+settings.listType+"><li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
+      else if (this_level <= level){ // higher level than before; end parent ol
+        for(i = this_level; i < level; i++) {
+          html += "</li></"+settings.listType+">"
+        }
+        html += "<li><a href='#" + header.id + "'>" + header.innerHTML + "</a>";
+      }
+      else if (this_level > level) { // lower level than before; expand the previous to contain a ol
+        for(i = this_level; i > level; i--) {
+          html += "<"+settings.listType+"><li>"
+        }
+        html += "<a href='#" + header.id + "'>" + header.innerHTML + "</a>";
+      }
       level = this_level; // update for the next one
     });
     html += "</"+settings.listType+">";


### PR DESCRIPTION
I tend to write documents like this:

 # Topic
 ## Subtopic
 ### Now getting into some detail
 # New topic

Currently toc.js renders this as
1.  Topic
   1.  Subtopic
      1.  Now getting into some detail
   2.  New topic

Whereas my desired rendering is
1.  Topic
   1.  Subtopic
      1.  Now getting into some detail
2.  New topic

This patch causes toc.js to take my `<h>` tags more seriously, so if I go from `<h3>` to `<h1>` I drop all the way out to the root level.
