### PR TITLE
fix an issue occurring when the previous sibling has no name.

### DIFF
--- a/toc.js
+++ b/toc.js
@@ -12,8 +12,9 @@
 
     var headers = $('h1, h2, h3, h4, h5, h6').filter(function() {
       // get all headers with an ID
-      if (!this.id) {
-        this.id = $(this).attr( "id", $(this).prev().attr( "name" ).replace(/\./g, "-") );
+      var previousSiblingName = $(this).prev().attr( "name" );
+      if (!this.id && previousSiblingName) {
+        this.id = $(this).attr( "id", previousSiblingName.replace(/\./g, "-") );
       }
       return this.id;
     }), output = $(this);


### PR DESCRIPTION
Hi,

I'm running into an issue when the previous sibling has no name attribute. The replace is applied on an undefined object and crashes.

Here is a fix. I'm simply testing the presence of a name attribute.
