### PR TITLE
Use innerText or textContent to filter out HTML blocks.

### DIFF
--- a/toc.js
+++ b/toc.js
@@ -20,9 +20,10 @@
         return '%' + c.charCodeAt(0).toString(16);
       });
     }
-    
+
     function createLink (header) {
-      return "<a href='#" + fixedEncodeURIComponent(header.id) + "'>" + header.innerHTML + "</a>";
+      var innerText = (header.textContent === undefined) ? header.innerText : header.textContent;
+      return "<a href='#" + fixedEncodeURIComponent(header.id) + "'>" + innerText + "</a>";
     }
 
     var headers = $(settings.headers).filter(function() {


### PR DESCRIPTION
Headers has inner HTML block with id will be set to TOC, this may cause
multiple id in page.

eg:
`<h2><a id="header-id"></a>Header</h2>`
`<h2><a name="header-id"></a>Header</h2>`

Use innerText to filter out the anchor block, so the TOC can has pure
text inside.